### PR TITLE
Makefile: Fix ordering of linker arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ realclean: clean
 include stats/Makefile
 
 harris: harris.o $(OBJS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(LDFLAGS) $(OBJS) $(LIBS) harris.o -o $@ $(SDL)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(OBJS) harris.o -o $@ $(LDFLAGS) $(LIBS) $(SDL)
 
 harris.o: harris.c $(INCLUDES)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) -o $@ -c $<

--- a/lib-w/Makefile.w32
+++ b/lib-w/Makefile.w32
@@ -18,7 +18,7 @@ SAVES := save/qstart.sav save/civ.sav save/abd.sav save/ruhr.sav
 all: harris.exe $(SAVES) dat/targets dat/cities/Saarbrucken.pbm dat/cities/Lubeck.pbm dat/cities/Peenemunde.pbm
 
 harris.exe: harris.o $(OBJS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(LDFLAGS) $(OBJS) $(LIBS) $(SDL) harris.o -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(OBJS) harris.o -o $@ $(LDFLAGS) $(LIBS) $(SDL)
 
 harris.o: harris.c $(INCLUDES)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) -o $@ -c $<

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,7 +21,7 @@ SDL := `sdl-config --libs` -lSDL_ttf -lSDL_gfx -lSDL_image
 SDLFLAGS := `sdl-config --cflags`
 
 harris:
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(LDFLAGS) $(OBJS) $(LIBS) harris.o -o $@ $(SDL)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(SDLFLAGS) $(OBJS) harris.o -o $@ $(LDFLAGS) $(LIBS) $(SDL)
 
 install:
 	install -d $(BINIDIR) $(DATIDIR)

--- a/stats/Makefile
+++ b/stats/Makefile
@@ -6,5 +6,5 @@ STATS_INCLUDES := $(STATS_OBJS:.o=.h)
 stats: stats/read_history stats/como stats/cshr stats/kills stats/fighters stats/raids stats/bombers
 
 stats/%: stats/%.c $(OBJS) $(STATS_OBJS) $(INCLUDES) $(STATS_INCLUDES)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -I . $(SDLFLAGS) $(LDFLAGS) $(LIBS) $< $(OBJS) $(STATS_OBJS) -o $@ $(SDL)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -I . $(SDLFLAGS) $< $(OBJS) $(STATS_OBJS) -o $@ $(LDFLAGS) $(LIBS) $(SDL)
 


### PR DESCRIPTION
Without this patch, the linking step would fail for me with errors like:
```
/bin/ld: date.o: undefined reference to symbol 'fmod@@GLIBC_2.2.5'
/lib64/libm.so.6: error adding symbols: DSO missing from command line
```
And those `LDFLAGS`: ` -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags`