### PR TITLE
Add run-time inspection of the system's installed version of Python.

### DIFF
--- a/gensave.py
+++ b/gensave.py
@@ -14,7 +14,10 @@ def multiply(line):
 def genids(line, i):
 	if line.endswith(',NOID\n'):
 		z = '_'.join((salt, str(i), line))
-		ha = zlib.crc32(z) & 0xffffffff
+		if sys.version_info.major > 2:
+			ha = zlib.crc32(bytes(z, encoding='utf-8')) & 0xffffffff
+		else:
+			ha = zlib.crc32(z) & 0xffffffff
 		h = hex(ha)[2:].rstrip('L')
 		return '%s,%s\n' % (line[:-6], h.zfill(8))
 	else:
@@ -42,7 +45,10 @@ def gencrews(line, i):
 	assi = int(words[4])
 	acid = words[5]
 	z = '_'.join((salt, str(i), line))
-	ha = zlib.crc32(z) & 0xffffffff
+	if sys.version_info.major > 2:
+		ha = zlib.crc32(bytes(z, encoding='utf-8')) & 0xffffffff
+	else:
+		ha = zlib.crc32(z) & 0xffffffff
 	random.seed(ha)
 	skill = poisson(ms)
 	lrate = poisson(ml)

--- a/install.py
+++ b/install.py
@@ -207,7 +207,8 @@ def install_file(opts, f, dir):
 	if not os.access(dd, os.F_OK):
 		os.makedirs(dd)
 	cmd = ' '.join(('install', '-m644', quote(os.path.join(pd, f)), quote(dd)))
-	print "install.py:", cmd
+	ostr = "install.py: %s"%cmd
+	print(ostr)
 	rc = os.system(cmd)
 	if rc:
 		raise Exception('Command', cmd, 'failed rc =', rc)

--- a/mkevents.py
+++ b/mkevents.py
@@ -7,7 +7,7 @@ from hdata import Events
 assert len(sys.argv) == 2, sys.argv
 
 if sys.argv[1] == 'h':
-	print """/*
+	print("""/*
 	harris - a strategy game
 	Copyright (C) 2012-2013 Edward Cree
 
@@ -18,20 +18,23 @@ if sys.argv[1] == 'h':
 
 #ifndef HAVE_EVENTS_H
 #define HAVE_EVENTS_H
-"""
+""")
 
 	for i,e in enumerate(Events):
-		print "#define EVENT_%s %d" % (e['id'], i)
+		ostr = "#define EVENT_%s %d" % (e['id'], i)
+		print(ostr)
 
-	print "#define NEVENTS %d" % len(Events)
-	print
-	print "extern const char *event_names[%d];" % len(Events)
-
-	print
-	print "#endif /* HAVE_EVENTS_H */"
+	ostr = "#define NEVENTS %d" % len(Events)
+	print(ostr)
+	print("")
+	ostr = "extern const char *event_names[%d];" % len(Events)
+	print(ostr)
+	print("")
+	ostr = "#endif /* HAVE_EVENTS_H */"
+	print(ostr)
 else:
 	assert sys.argv[1] == 'c', sys.argv
-	print """/*
+	print("""/*
 	harris - a strategy game
 	Copyright (C) 2012-2013 Edward Cree
 
@@ -41,9 +44,11 @@ else:
 */
 
 #include "events.h"
-"""
+""")
 
-	print "const char *event_names[%d]={" % len(Events)
+	ostr = "const char *event_names[%d]={" % len(Events)
+	print(ostr)
 	for e in Events:
-		print '\t"%s",' % e['id']
-	print "};"
+		ostr = '\t"%s",' % e['id']
+		print(ostr)
+	print("};")

--- a/stats/como.py
+++ b/stats/como.py
@@ -48,4 +48,5 @@ def extract_como(f):
 if __name__ == '__main__':
 	como = extract_como(sys.stdin)
 	for cm in como:
-		print '%s: confid=%d morale=%d' % (cm['date'], cm['confid'], cm['morale'])
+		ostr = '%s: confid=%d morale=%d' % (cm['date'], cm['confid'], cm['morale'])
+		print(ostr)

--- a/stats/compose_cities.py
+++ b/stats/compose_cities.py
@@ -74,9 +74,9 @@ if len(sys.argv) > 2:
 	cx = int(sys.argv[1])
 	cy = int(sys.argv[2])
 
-print "P3"
-print "256 256"
-print "15"
+print("P3")
+print("256 256")
+print("15")
 for y in xrange(256):
 	for x in xrange(256):
 		if citymap[y][x]<0:
@@ -96,4 +96,5 @@ for y in xrange(256):
 				return [max(v-br, 0) for v in l]
 			[r, g, b] = mark(d, [r, g, b], 5)
 			[r, g, b] = mark(d, [r, g, b], 20)
-		print "%d %d %d" %(r, g, b)
+		ostr = "%d %d %d" %(r, g, b)
+		print(ostr)

--- a/stats/cshr.py
+++ b/stats/cshr.py
@@ -24,4 +24,5 @@ def extract_cshr(f):
 if __name__ == '__main__':
 	cshr = extract_cshr(sys.stdin)
 	for c in sorted(cshr):
-		print '%s: cshr=%d' % (c, cshr[c])
+		ostr = '%s: cshr=%d' % (c, cshr[c])
+		print(ostr)

--- a/stats/fighterkill.py
+++ b/stats/fighterkill.py
@@ -41,4 +41,5 @@ if __name__ == '__main__':
 	kills = extract_kills(sys.stdin)
 	by_type = [(hdata.Fighters[i]['name'], sum([d['kills'][i] for d in kills.values()]), sum([d['losses'][i] for d in kills.values()])) for i in xrange(len(hdata.Fighters))]
 	for b in by_type:
-		print "%s: kills=%d losses=%d"%b
+		ostr = "%s: kills=%d losses=%d"%b
+		print(ostr)

--- a/stats/hdata.py
+++ b/stats/hdata.py
@@ -60,6 +60,8 @@ class Table(object):
 		return None
 
 def parse_string(text):
+	if sys.version_info.major > 2:
+		return text.strip()
 	return unicode(text.strip(), encoding='utf8')
 parse_int = int
 def parse_date(text):
@@ -159,23 +161,30 @@ Locations.read(open('dat/locations'))
 
 if __name__ == "__main__":
 	if '--bombers' in sys.argv or '--all' in sys.argv:
-		print '%d bombers' % len(Bombers)
-		print Bombers
+		ostr = '%d bombers' % len(Bombers)
+		print(ostr)
+		print(Bombers)
 	if '--events' in sys.argv or '--all' in sys.argv:
-		print '%d events' % len(Events)
-		print Events
+		ostr = '%d events' % len(Events)
+		print(ostr)
+		print(Events)
 	if '--fighters' in sys.argv or '--all' in sys.argv:
-		print '%d fighters' % len(Fighters)
-		print Fighters
+		ostr = '%d fighters' % len(Fighters)
+		print(ostr)
+		print(Fighters)
 	if '--flaksites' in sys.argv or '--all' in sys.argv:
-		print '%d flaksites' % len(Flak)
-		print Flak
+		ostr = '%d flaksites' % len(Flak)
+		print(ostr)
+		print(Flak)
 	if '--ftrbases' in sys.argv or '--all' in sys.argv:
-		print '%d ftrbases' % len(Ftrbases)
-		print Ftrbases
+		ostr = '%d ftrbases' % len(Ftrbases)
+		print(ostr)
+		print(Ftrbases)
 	if '--locations' in sys.argv or '--all' in sys.argv:
-		print '%d locations' % len(Locations)
-		print Locations
+		ostr = '%d locations' % len(Locations)
+		print(ostr)
+		print(Locations)
 	if '--targets' in sys.argv or '--all' in sys.argv:
-		print '%d targets' % len(Targets)
-		print Targets
+		ostr = '%d targets' % len(Targets)
+		print(ostr)
+		print(Targets)

--- a/stats/hhist.py
+++ b/stats/hhist.py
@@ -266,4 +266,5 @@ def import_from_save(f, crew_hist=False):
 
 if __name__ == '__main__':
 	entries = import_from_save(sys.stdin)
-	print 'Imported %d entries' % len(entries)
+	ostr = 'Imported %d entries' % len(entries)
+	print(ostr)

--- a/stats/hsave.py
+++ b/stats/hsave.py
@@ -49,8 +49,8 @@ class Save(object):
 				else:
 					stage, nosplit = self.handle(tag, rest)
 			except Exception as e:
-				print 'Choked on the following line:'
-				print line
+				print('Choked on the following line:')
+				print(line)
 				raise
 		if check_integrity:
 			self.check_integrity()
@@ -296,6 +296,7 @@ class Save(object):
 
 if __name__ == '__main__':
 	save = Save.parse(sys.stdin)
-	print 'Parsed save OK'#; replaying event log...'
+	print('Parsed save OK')
+	#print('replaying event log...')
 	#save.check_integrity()
-	#print 'Integrity OK'
+	#print('Integrity OK')

--- a/stats/losstarg.py
+++ b/stats/losstarg.py
@@ -33,4 +33,4 @@ def extract_losstarg(f, opts):
 if __name__ == '__main__':
 	opts, args = parse_args(sys.argv)
 	losstarg = extract_losstarg(sys.stdin, opts)
-	print losstarg
+	print(losstarg)

--- a/stats/losstype.py
+++ b/stats/losstype.py
@@ -91,7 +91,8 @@ def parse_args(argv):
 
 if __name__ == '__main__':
 	def tbl_row(n, s, l, p):
-		print "%s: %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5))
+		ostr = "%s: %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5))
+		print(ostr)
 	def tbl_nrow(n, s, l, p):
 		tbl_row(n, str(s), str(l), "%5.2f"%p if p is not None else "  -  ")
 	opts, args = parse_args(sys.argv)
@@ -100,7 +101,8 @@ if __name__ == '__main__':
 	if opts.stratify:
 		overall, losstype = stratified_losstype(sys.stdin, after, before)
 		def tbl_row(n, s, l, p, q):
-			print "%s: %s %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5), q.rjust(5))
+			ostr = "%s: %s %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5), q.rjust(5))
+			print(ostr)
 		def tbl_nrow(n, s, l, p, q):
 			tbl_row(n, str(s), str(l), "%5.2f"%p if p is not None else "  -  ", "%5.2f"%q if q is not None else "  -  ")
 		tbl_row("NAME", "Sorties", "Losses", "Loss%", "Strat%")
@@ -112,7 +114,8 @@ if __name__ == '__main__':
 	else:
 		overall, losstype = extract_losstype(sys.stdin, after, before)
 		def tbl_row(n, s, l, p):
-			print "%s: %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5))
+			ostr = "%s: %s %s %s"%(n.rjust(4), s.rjust(7), l.rjust(7), p.rjust(5))
+			print(ostr)
 		def tbl_nrow(n, s, l, p):
 			tbl_row(n, str(s), str(l), "%5.2f"%p if p is not None else "  -  ")
 		tbl_row("NAME", "Sorties", "Losses", "Loss%")

--- a/stats/prodloss.py
+++ b/stats/prodloss.py
@@ -26,4 +26,5 @@ if __name__ == '__main__':
 	entries = hhist.import_from_save(sys.stdin)
 	prodloss = extract_prodloss(entries)
 	for d in sorted(prodloss):
-		print '%s: %s' % (d, prodloss[d])
+		ostr = '%s: %s' % (d, prodloss[d])
+		print(ostr)

--- a/stats/profit.py
+++ b/stats/profit.py
@@ -32,7 +32,8 @@ def daily_profit(d, bombers, targets, classes, start, stop, typ=None, targ_id=No
 					bombers[acid]=[int(h['data']['type']['ti']), 0, True, True]
 				else:
 					if acid not in bombers:
-						print 'Warning: un-inited bomber %08x'%acid
+						ostr = 'Warning: un-inited bomber %08x'%acid
+						print(ostr)
 					elif h['data']['etyp'] in ['CR', 'OB']:
 						bombers[acid][2] = False
 						if not start:
@@ -217,7 +218,8 @@ if __name__ == '__main__':
 			else:
 				if not gain: continue
 				ratio = '--'
-			print "%s: %9d / %9d = %s" % (name, gain, loss, ratio)
+			ostr = "%s: %9d / %9d = %s" % (name, gain, loss, ratio)
+			print(ostr)
 	else:
 		profit = extract_profit(save, before, after, targ_id=opts.targ)
 		for i in profit:
@@ -225,4 +227,5 @@ if __name__ == '__main__':
 			full = "(%d) = %g" % (profit[i]['full'][0], profit[i]['fullr'])
 			dead = "(%d) = %g" % (profit[i]['dead'][0], profit[i]['deadr'])
 			opti = "%g" % (profit[i]['opti'])
-			print "%s: all%s, dead%s, optimistic %s, cost %d" % (name, full, dead, opti, hdata.Bombers[i]['cost'])
+			ostr = "%s: all%s, dead%s, optimistic %s, cost %d" % (name, full, dead, opti, hdata.Bombers[i]['cost'])
+			print(ostr)

--- a/stats/tombstone.py
+++ b/stats/tombstone.py
@@ -24,13 +24,14 @@ if __name__ == '__main__':
 	entries = hhist.import_from_save(sys.stdin, crew_hist=True)
 	tombstone, pw, ex = count_losses(entries)
 	if not tombstone:
-		print 'No losses have yet been incurred!'
+		print('No losses have yet been incurred!')
 	else:
 		if tombstone == 1:
-			print '1 airman has been Killed In Action'
+			print('1 airman has been Killed In Action')
 		else:
-			print '%d airmen have been Killed In Action' % tombstone
-		print r'''
+			ostr = '%d airmen have been Killed In Action' % tombstone
+			print(ostr)
+		print(r'''
       ----
      /    \
     /      \
@@ -41,10 +42,12 @@ if __name__ == '__main__':
    |  THEM  |
  \ | \ ,   /| o
 -|/-\|-|--\|-\|/
-'''
+''')
 	if pw or ex:
-		print
+		print("")
 	if pw:
-		print '(PoW count: %d)' % pw
+		ostr = '(PoW count: %d)' % pw
+		print(ostr)
 	if ex:
-		print '(esc count: %d)' % ex
+		ostr = '(esc count: %d)' % ex
+		print(ostr)

--- a/stats/totalraids.py
+++ b/stats/totalraids.py
@@ -19,12 +19,14 @@ def daily_total(d, bombers, start, stop): # updates bombers
 					del bombers[acid]
 				elif h['data']['etyp'] == 'RA':
 					if acid not in bombers:
-						print 'Warning: un-inited bomber %08x'%acid
+						ostr = 'Warning: un-inited bomber %08x'%acid
+						print(ostr)
 						bombers[acid] = False
 					totals[int(bombers[acid])] += 1
 				elif h['data']['etyp'] == 'PF':
 					if acid not in bombers:
-						print 'Warning: un-inited bomber %08x'%acid
+						ostr = 'Warning: un-inited bomber %08x'%acid
+						print(ostr)
 					bombers[acid] = True
 	return totals
 
@@ -55,8 +57,11 @@ if __name__ == '__main__':
 		m,p = totals[d]
 		if m or p:
 			if pff and d < pff['date']:
-				print '%s: %d'%(d,m)
+				ostr = '%s: %d'%(d,m)
+				print(ostr)
 				if p:
-					print '(Unexpected PFF: %s)'%p
+					ostr = '(Unexpected PFF: %s)'%p
+					print(ostr)
 			else:
-				print '%s: %d (%d main force, %d PFF)'%(d,m+p,m,p)
+				ostr = '%s: %d (%d main force, %d PFF)'%(d,m+p,m,p)
+				print(ostr)

--- a/stats/value.py
+++ b/stats/value.py
@@ -46,7 +46,8 @@ def extract_value(f):
 		for i,b in enumerate(hdata.Bombers):
 			if b['exit'] and d == b['exit'].next():
 				if bcount[i]:
-					print 'Warning: %d leftover %s' % (bcount[i], b['name'])
+					ostr = 'Warning: %d leftover %s' % (bcount[i], b['name'])
+					print(ostr)
 					bcount[i] = 0 # force it to 0
 		bvalues = [b*hdata.Bombers[i]['cost'] for i,b in enumerate(bcount)]
 		built = records[d]['+']
@@ -68,4 +69,5 @@ def extract_value(f):
 if __name__ == '__main__':
 	value = extract_value(sys.stdin)
 	for row in value:
-		print '%s: %s; %7d+%6d/ => %8d (%+7d)'%(row['date'], ','.join('%3d'%b for b in row['bombers']), row['cash'], row['cshr'], row['project'], row.get('deltap', 0))
+		ostr = '%s: %s; %7d+%6d/ => %8d (%+7d)'%(row['date'], ','.join('%3d'%b for b in row['bombers']), row['cash'], row['cshr'], row['project'], row.get('deltap', 0))
+		print(ostr)

--- a/upconvert.py
+++ b/upconvert.py
@@ -63,7 +63,8 @@ if __name__ == "__main__":
             sys.stderr.write("Save file is too old (version %s)\n"%ver)
             sys.stderr.write("  Supported: %s\n"%(', '.join(sorted(changes))))
             sys.exit(1)
-        print 'HARR:%s'%opts.tover
+        ostr = 'HARR:%s'%opts.tover
+        print(ostr)
         # prepare: accumulate changes
         cbe = {} # changes by entity, ent => {oldindex => newindex}
         for ent in entities:
@@ -112,17 +113,19 @@ if __name__ == "__main__":
                     acid, bft, data = data.split(' ', 2)
                     if bft[0] == 'B':
                         typ = int(bft[1:])
-                        print ' '.join((date, time, klass, acid, 'B%d'%cbe['type'][typ], data))
+                        ostr = ' '.join((date, time, klass, acid, 'B%d'%cbe['type'][typ], data))
+                        print(ostr)
                         continue
                 ch -= 1
             borf = popntag('Type', line)
             if borf:
                 if cb: # Type <btype>:<failed>,<navs>,<pff>,<acid> // bomber
                     typ = int(borf[0])
-                    print 'Type %d:%s'%(cbe['type'][typ], borf[1])
+                    ostr = 'Type %d:%s'%(cbe['type'][typ], borf[1])
+                    print(ostr)
                     cb -= 1
                 elif cf: # Type <ftype>:<base>,<radar>,<acid> // fighter
-                    print line
+                    print(line)
                     cf -= 1
                 else: # neither bomber nor fighter expected
                     raise Exception("Unexpected 'Type' tag in line", line)
@@ -132,29 +135,36 @@ if __name__ == "__main__":
             elif cf:
                 raise Exception("Expected fighter ('Type' tag) but got line", line)
             if line.startswith('DClasses:'):
-                print 'DClasses:%d'%newc['dclass']
+                ostr = 'DClasses:%d'%newc['dclass']
+                print(ostr)
                 continue
             diff = poptag('Difficulty', line)
             if diff:
                 klass, level = map(int, diff)
-                print 'Difficulty:%d,%d'%(cbe['dclass'][klass], level)
+                ostr = 'Difficulty:%d,%d'%(cbe['dclass'][klass], level)
+                print(ostr)
                 continue
             if line.startswith('Types:'):
-                print 'Types:%d'%newc['type']
+                ostr = 'Types:%d'%newc['type']
+                print(ostr)
                 continue
             prio = popntag('Prio', line)
             if prio:
                 typ = int(prio[0])
                 for i in range(cbe['type'][typ-1]+1 if typ else 0, cbe['type'][typ]):
-                    print 'NoType %d'%i
-                print 'Prio %d:%s'%(cbe['type'][typ], prio[1])
+                    ostr = 'NoType %d'%i
+                    print(ostr)
+                ostr = 'Prio %d:%s'%(cbe['type'][typ], prio[1])
+                print(ostr)
                 continue
             notype = popntag('NoType', line)
             if notype:
                 typ = int(notype[0])
                 for i in range(cbe['type'][typ-1]+1 if typ else 0, cbe['type'][typ]):
-                    print 'NoType %d:'%i
-                print 'NoType %d:'%cbe['type'][typ]
+                    ostr = 'NoType %d:'%i
+                    print(ostr)
+                ostr = 'NoType %d:'%cbe['type'][typ]
+                print(ostr)
                 continue
             nbombers = poptag('Bombers', line)
             if nbombers:
@@ -165,4 +175,4 @@ if __name__ == "__main__":
             history = poptag('History', line)
             if history:
                 ch = int(history[0])
-            print line
+            print(line)


### PR DESCRIPTION
The project's '.py' scripts should be able to execute and the project's build process should be completing on either 'Python v2' or 'Python v3' systems. This pull request should resolve #7 **Compilation error while building "globals.h:27: 'NEVENTS' not declared here"**.

A few general notes on the modifications that I've applied across the scripts:
- In three cases, I added an `if / else` conditional that branches based upon whether the installed/tested Python version is greater-than-2 or not.
- In many other cases, I updated occurrences of existing Python v2-specific `print` statement syntax so that all are now non-specific to the version of Python that is present. This required splitting each of the old `print "foo" % bar` statements into new statement combinations that consist of one output-string assignment (i.e. `ostr = "foo" % bar`) followed by the printing of that output-string (i.e. `print(ostr)`).
- On other occasions, for the simpler print statements that are not performing any string substitutions, my modification would merely require the addition of parentheses, such as `print("foo")`.

Please review my comment that I've left at the issue #7 comment thread.
